### PR TITLE
Updates the `check` command with an optional `--file` flag and provides updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@ The [Changelogger tool](https://pypi.org/project/changelogged) is used for autom
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
 
-#### Added
-- Something
+### [0.10.0] - 2023-03-05
 
+#### Added
+- Alias commands `up` and `ch` for `upgrade` and `check`, respectively.
+- Add the `--file` option to the check command, allowing users to specify which files to check.
+- Added progress feedback as versioned files are checked.
 
 ### [0.9.1] - 2023-03-05
 
@@ -119,7 +122,8 @@ The [Changelogger tool](https://pypi.org/project/changelogged) is used for autom
 - `unreleased add`, which allows inline or prompted adding of unreleased changes.
 <!-- END RELEASE NOTES -->
 <!-- BEGIN LINKS -->
-[Unreleased]: https://github.com/award28/changelogger/compare/0.9.1...HEAD
+[Unreleased]: https://github.com/award28/changelogger/compare/0.10.0...HEAD
+[0.10.0]: https://github.com/award28/changelogger/compare/0.9.1...0.10.0
 [0.9.1]: https://github.com/award28/changelogger/compare/0.9.0...0.9.1
 [0.9.0]: https://github.com/award28/changelogger/compare/0.8.0...0.9.0
 [0.8.0]: https://github.com/award28/changelogger/compare/0.7.0...0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The [Changelogger tool](https://pypi.org/project/changelogged) is used for autom
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
 
+#### Added
+- Something
+
+
 ### [0.9.1] - 2023-03-05
 
 #### Changed

--- a/changelogger/app/commands/check.py
+++ b/changelogger/app/commands/check.py
@@ -5,7 +5,6 @@ from rich import print
 from rich.progress import Progress
 
 from changelogger import changelog, templating
-from changelogger.app.commands.notes import _unreleased_notes
 from changelogger.conf import settings
 from changelogger.conf.models import VersionedFile
 from changelogger.exceptions import ValidationException
@@ -68,7 +67,7 @@ def _check_versioned_files(versioned_files: list[VersionedFile]) -> None:
     update = ChangelogUpdate(
         new_version=old_version.bump_minor(),
         old_version=old_version,
-        release_notes=_unreleased_notes(),
+        release_notes=changelog.get_release_notes("Unreleased", old_version),
     )
 
     counts = Counter(file.rel_path for file in versioned_files)

--- a/changelogger/app/commands/check.py
+++ b/changelogger/app/commands/check.py
@@ -38,10 +38,13 @@ def check(
             if str(file.rel_path) in files_set
         ]
     )
-    check_changelog = str(settings.CHANGELOG_PATH) in files
     try:
         _check_versioned_files(versioned_files)
-        if check_changelog:
+
+        if any(
+            file.rel_path == settings.CHANGELOG_PATH
+            for file in versioned_files
+        ):
             _check_changelog()
 
     except ValidationException as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "changelogged"
-version = "0.9.1"
+version = "0.10.0"
 description = "Automated management of your changelog and other versioned files, following the principles of Keep a Changelog and Semantic Versioning."
 license = "MIT"
 authors = ["award28 <austin.ward@klaviyo.com>"]

--- a/tests/app/commands/test_check.py
+++ b/tests/app/commands/test_check.py
@@ -19,6 +19,13 @@ class TestManageCheckCommand:
             yield mock
 
     @pytest.fixture
+    def mock_check_versioned_files(self):
+        with patch(
+            "changelogger.app.commands.check._check_versioned_files"
+        ) as mock:
+            yield mock
+
+    @pytest.fixture
     def mock_changelog(self):
         with patch("changelogger.app.commands.check.changelog") as mock:
             yield mock
@@ -38,29 +45,46 @@ class TestManageCheckCommand:
         with patch("changelogger.app.commands.check.templating") as mock:
             yield mock
 
+    @pytest.fixture
+    def mock_settings(self):
+        with patch("changelogger.app.commands.check.settings") as mock:
+            yield mock
+
+    @pytest.fixture
+    def mock_versioned_files(self, mock_settings: MagicMock):
+        mock_versioned_file = MagicMock()
+        mock_versioned_file.rel_path = mock_settings.CHANGELOG_PATH
+        mock_settings.VERSIONED_FILES = [mock_versioned_file]
+
     def test_check_changelog_no_errors(
         self,
+        mock_check_versioned_files: MagicMock,
+        mock_versioned_files: MagicMock,
         mock_check_changelog: MagicMock,
         mock_print: MagicMock,
     ) -> None:
-        check()
+        check(files=[])
         mock_check_changelog.assert_called_once_with()
         mock_print.assert_called_once()
-        assert "All versioned files are valid!" in mock_print.call_args.args[0]
+        assert "Versioned files are valid!" in mock_print.call_args.args[0]
 
     def test_check_changelog_with_errors(
         self,
+        mock_check_versioned_files: MagicMock,
+        mock_versioned_files: MagicMock,
         mock_check_changelog: MagicMock,
         mock_print: MagicMock,
     ) -> None:
         exc_note = "Some validation exception"
         mock_check_changelog.side_effect = ValidationException(exc_note)
-        check(sys_exit=False)
+        check(sys_exit=False, files=[])
         mock_print.assert_called_once()
         assert exc_note in mock_print.call_args.args[0]
 
     def test_check_changelog_with_error_and_exit(
         self,
+        mock_check_versioned_files: MagicMock,
+        mock_versioned_files: MagicMock,
         mock_check_changelog: MagicMock,
         mock_print: MagicMock,
     ) -> None:
@@ -68,7 +92,7 @@ class TestManageCheckCommand:
         mock_check_changelog.side_effect = ValidationException(exc_note)
 
         with pytest.raises(Exit):
-            check(sys_exit=True)
+            check(sys_exit=True, files=[])
 
         mock_print.assert_called_once()
         assert exc_note in mock_print.call_args.args[0]

--- a/tests/app/commands/test_check.py
+++ b/tests/app/commands/test_check.py
@@ -75,11 +75,9 @@ class TestCheckCommand(CheckCommandFixtures):
         self,
         mock_check_versioned_files: MagicMock,
         mock_versioned_files: MagicMock,
-        mock_check_changelog: MagicMock,
         mock_print: MagicMock,
     ) -> None:
         check(files=[])
-        mock_check_changelog.assert_called_once_with()
         mock_print.assert_called_once()
         assert "Versioned files are valid!" in mock_print.call_args.args[0]
 
@@ -87,11 +85,10 @@ class TestCheckCommand(CheckCommandFixtures):
         self,
         mock_check_versioned_files: MagicMock,
         mock_versioned_files: MagicMock,
-        mock_check_changelog: MagicMock,
         mock_print: MagicMock,
     ) -> None:
         exc_note = "Some validation exception"
-        mock_check_changelog.side_effect = ValidationException(exc_note)
+        mock_check_versioned_files.side_effect = ValidationException(exc_note)
         check(sys_exit=False, files=[])
         mock_print.assert_called_once()
         assert exc_note in mock_print.call_args.args[0]
@@ -100,11 +97,10 @@ class TestCheckCommand(CheckCommandFixtures):
         self,
         mock_check_versioned_files: MagicMock,
         mock_versioned_files: MagicMock,
-        mock_check_changelog: MagicMock,
         mock_print: MagicMock,
     ) -> None:
         exc_note = "Some validation exception"
-        mock_check_changelog.side_effect = ValidationException(exc_note)
+        mock_check_versioned_files.side_effect = ValidationException(exc_note)
 
         with pytest.raises(Exit):
             check(sys_exit=True, files=[])
@@ -173,7 +169,7 @@ class TestCheckCommand(CheckCommandFixtures):
     ):
         validation_stepper(mock_changelog, point_of_failure)
         with pytest.raises(ValidationException) as exc_info:
-            _check_changelog()
+            _check_changelog(MagicMock())
 
         assert exc_note in exc_info.value.args[0]
 
@@ -182,7 +178,7 @@ class TestCheckCommand(CheckCommandFixtures):
         mock_changelog: MagicMock,
     ):
         validation_stepper(mock_changelog, 7)
-        _check_changelog()
+        _check_changelog(MagicMock())
 
 
 def validation_stepper(mock_changelog: MagicMock, pof: int):

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -6,7 +6,7 @@ from freezegun import freeze_time
 from changelogger import templating
 
 
-class TestTemplating:
+class TemplatingFixtures:
     @pytest.fixture
     def mock_jinja_environment(self):
         with patch(
@@ -29,6 +29,13 @@ class TestTemplating:
             yield mock
 
     @pytest.fixture
+    def mock_render_jinja(self):
+        with patch(
+            "changelogger.templating.render_jinja",
+        ) as mock:
+            yield mock
+
+    @pytest.fixture
     def mock_tmpl(self):
         with patch(
             "changelogger.templating._tmpl",
@@ -42,6 +49,8 @@ class TestTemplating:
         ) as mock:
             yield mock
 
+
+class TestTemplating(TemplatingFixtures):
     def test_tmpl(
         self,
         mock_jinja_environment: MagicMock,
@@ -73,6 +82,22 @@ class TestTemplating:
         assert str(tmpl_variables["today"]) == self.FROZEN_DATE
         assert tmpl_variables["sections"] == update.release_notes.dict()
         assert tmpl_variables["context"] == versioned_file.context
+
+    def test_render_pattern(
+        self,
+        mock_get_variables: MagicMock,
+        mock_render_jinja: MagicMock,
+    ) -> None:
+        file, update = MagicMock(), MagicMock()
+        templating.render_pattern(
+            file,
+            update,
+        )
+        mock_get_variables.assert_called_once_with(
+            file,
+            update,
+        )
+        mock_render_jinja.assert_called_once()
 
     def test_update_neither_jinja_raises(
         self,


### PR DESCRIPTION
Resolves #61.
- #61 

```bash
❯ cl check
Checking "pyproject.toml" ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Checking "CHANGELOG.md"   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
✅ Versioned files are valid!
```